### PR TITLE
Fix GitHub Pages workflow to include .nojekyll

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build (with proper base for GitHub Pages)
         run: npm run build -- --base=/${{ github.event.repository.name }}/
 
+      - name: Add .nojekyll
+        run: touch dist/.nojekyll
+
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -39,9 +42,4 @@ jobs:
           publish_dir: ./dist
           publish_branch: gh-pages
           force_orphan: true
-
-      - name: Add .nojekyll
-        if: always()
-        run: |
-          touch dist/.nojekyll
 


### PR DESCRIPTION
## Summary
- ensure `.nojekyll` is created before deploying to `gh-pages`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c69d28290c832198cceee55ce7184f